### PR TITLE
getARGV.idp should be included and not loaded

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -4011,7 +4011,7 @@ FreeFem++ script.edp -n 10 -a 1. -d 42.
 
 The arguments can be used in the script with:
 ```freefem
-load "getARGV.idp"
+include "getARGV.idp"
 
 int n = getARGV("n", 1);
 real a = getARGV("a", 1.);

--- a/docs/reference/GlobalVariables.md
+++ b/docs/reference/GlobalVariables.md
@@ -114,7 +114,7 @@ real L = int1d(Th, 1)(lenEdge);
 ## load
 Load a script.
 ```freefem
-load "getARGV.idp"
+load "Element_P3"
 ```
 
 ## LU


### PR DESCRIPTION
In docs/reference/GlobalVariables.md I loaded `Element_P3` but any other script can be loaded

