### PR TITLE
Typos in documentation

### DIFF
--- a/docs/models/EigenValueProblems.md
+++ b/docs/models/EigenValueProblems.md
@@ -18,7 +18,7 @@ The return value is the number of converged eigenvalues (can be greater than the
 int k = EigenValue(OP, B, nev=Nev, sigma=Sigma);
 ```
 
-where the matrix $OP= A - \sigma B $ with a solver and boundary condition, and the matrix $B$.
+where the matrix $OP= A - \sigma B$ with a solver and boundary condition, and the matrix $B$.
 
 There is also a functional interface:
 

--- a/docs/models/Elasticity.md
+++ b/docs/models/Elasticity.md
@@ -35,7 +35,7 @@ $$
 
 The tensor $e_{ij}$ is called _finite strain tensor_.
 
-Consider the small plane $\Delta \Pi(\mathbf{x})$ centered at $\mathbf{x}$ with the unit normal direction $\matbhf{n}=(n_1,n_2,n_3)$, then the surface on $\Delta \Pi(\mathbf{x})$ at $\mathbf{x}$ is
+Consider the small plane $\Delta \Pi(\mathbf{x})$ centered at $\mathbf{x}$ with the unit normal direction $\mathbf{n}=(n_1,n_2,n_3)$, then the surface on $\Delta \Pi(\mathbf{x})$ at $\mathbf{x}$ is
 
 $$
 (\sigma_{1j}(\mathbf{x})n_j, \sigma_{2j}(\mathbf{x})n_j, \sigma_{3j}(\mathbf{x})n_j)


### PR DESCRIPTION
Changes proposed in this pull request:
 - Corrected typos in Elasticity and EigenValue
 - 

