### PR TITLE
Update parallelization.rst

### DIFF
--- a/source/documentation/parallelization.rst
+++ b/source/documentation/parallelization.rst
@@ -120,7 +120,7 @@ MPI Communicator operator
    mpiComm comm(mpiCommWorld, 0, 0);
    mpiRequest req;
 
-   //send a,b asynchronously to the process 1
+   //send a,b synchronously to the process 1
    processor(1) << a << b;
    //receive a,b synchronously from the process 10
    processor(10) >> a >> b;


### PR DESCRIPTION
Correct typo in the comment above the example of sending data with the operator `<<` from `operator(i)` (without request, and thus synchronous).