### PR TITLE
Add missing parameter to `atan2` function docs

### DIFF
--- a/source/references/functions.rst
+++ b/source/references/functions.rst
@@ -310,7 +310,7 @@ atan2
 
    real theta = atan2(y, x)
 
-Parameter:
+Parameters:
 
 -  ``y`` (:freefem:`real`)
 -  ``x`` (:freefem:`real`)

--- a/source/references/functions.rst
+++ b/source/references/functions.rst
@@ -312,6 +312,7 @@ atan2
 
 Parameter:
 
+-  ``y`` (:freefem:`real`)
 -  ``x`` (:freefem:`real`)
 
 Output:


### PR DESCRIPTION
Changes proposed in this pull request:
 - Add missing documentation for `y` parameter of the `atan2` function. Not a very big issue, but this typo annoyed me.

